### PR TITLE
Remove hardcoded JWT signing key

### DIFF
--- a/README.en.md
+++ b/README.en.md
@@ -146,6 +146,16 @@ Please read the deployment documentation:
 
 https://docs.pickmall.cn
 
+### JWT secret configuration
+
+The JWT signing secret must be injected by the deployment environment and must not be committed to the repository. It must be a Base64-encoded key containing at least 32 bytes of key material, for example:
+
+```bash
+export LILI_JWT_SECRET="$(openssl rand -base64 32)"
+```
+
+All API services must use the same `LILI_JWT_SECRET`. The service fails during startup when this variable is not configured.
+
 Supports:
 
 - Docker deployment

--- a/README.md
+++ b/README.md
@@ -83,6 +83,15 @@ LILISHOP 是基于 Spring Boot / Spring Cloud / Vue / Uniapp 开发的 Java 开�
 -   **手动方式**: 如果您选择手动部署，SQL脚本位于以下地址。请确保获取与您代码版本一致的SQL文件。
     [**数据库脚本 (Gitee)**](https://gitee.com/beijing_hongye_huicheng/docker/tree/master/init/mysql)
 
+#### JWT密钥配置
+JWT签名密钥必须由部署环境注入，不要提交到代码仓库。密钥需要是至少 32 字节密钥材料的 Base64 编码，例如：
+
+```bash
+export LILI_JWT_SECRET="$(openssl rand -base64 32)"
+```
+
+所有 API 服务必须使用同一个 `LILI_JWT_SECRET`。未配置该变量时，服务会在启动时失败。
+
 ---
 
 ### 5. 技术架构

--- a/buyer-api/src/main/resources/application.yml
+++ b/buyer-api/src/main/resources/application.yml
@@ -165,6 +165,8 @@ lili:
 
   # jwt 细节设定
   jwt-setting:
+    # Base64-encoded JWT signing key, injected per deployment.
+    secret: ${LILI_JWT_SECRET:}
     # token过期时间（分钟）
     tokenExpireTime: 259200
 

--- a/buyer-api/src/test/resources/application.yml
+++ b/buyer-api/src/test/resources/application.yml
@@ -200,6 +200,8 @@ lili:
 
   # jwt 细节设定
   jwt-setting:
+    # Base64-encoded JWT signing key, injected per deployment.
+    secret: ${LILI_JWT_SECRET:}
     # token过期时间（分钟）
     tokenExpireTime: 60
 

--- a/common-api/src/main/resources/application.yml
+++ b/common-api/src/main/resources/application.yml
@@ -162,6 +162,8 @@ lili:
     currentOnlineUpdate: 600
   # jwt 细节设定
   jwt-setting:
+    # Base64-encoded JWT signing key, injected per deployment.
+    secret: ${LILI_JWT_SECRET:}
     # token过期时间（分钟）
     tokenExpireTime: 60
 

--- a/config/application.yml
+++ b/config/application.yml
@@ -226,6 +226,8 @@ lili:
 
   # jwt 细节设定
   jwt-setting:
+    # Base64-encoded JWT signing key, injected per deployment.
+    secret: ${LILI_JWT_SECRET:}
     # token过期时间（分钟）
     tokenExpireTime: 10000
 

--- a/consumer/src/main/resources/application.yml
+++ b/consumer/src/main/resources/application.yml
@@ -154,6 +154,8 @@ lili:
     currentOnlineUpdate: 600
   # jwt 细节设定
   jwt-setting:
+    # Base64-encoded JWT signing key, injected per deployment.
+    secret: ${LILI_JWT_SECRET:}
     # token过期时间（分钟）
     tokenExpireTime: 60
 

--- a/deploy-api.yml
+++ b/deploy-api.yml
@@ -352,6 +352,8 @@ data:
 
       # jwt 细节设定
       jwt-setting:
+        # Base64-encoded JWT signing key, injected per deployment.
+        secret: ${LILI_JWT_SECRET:}
         # token过期时间（分钟）
         tokenExpireTime: 30
 

--- a/framework/src/main/java/cn/lili/common/properties/JWTTokenProperties.java
+++ b/framework/src/main/java/cn/lili/common/properties/JWTTokenProperties.java
@@ -1,8 +1,12 @@
 package cn.lili.common.properties;
 
+import jakarta.validation.constraints.AssertTrue;
+import jakarta.validation.constraints.NotBlank;
+import io.jsonwebtoken.io.Decoders;
 import lombok.Data;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.validation.annotation.Validated;
 
 /**
  * token过期配置
@@ -11,9 +15,28 @@ import org.springframework.context.annotation.Configuration;
  */
 @Data
 @Configuration
+@Validated
 @ConfigurationProperties(prefix = "lili.jwt-setting")
 public class JWTTokenProperties {
 
+
+    /**
+     * Base64-encoded JWT signing key. It must be supplied by the deployment.
+     */
+    @NotBlank(message = "lili.jwt-setting.secret must be configured")
+    private String secret;
+
+    @AssertTrue(message = "lili.jwt-setting.secret must be Base64 encoded key with at least 32 bytes")
+    public boolean isSecretKeySizeValid() {
+        if (secret == null || secret.isBlank()) {
+            return true;
+        }
+        try {
+            return Decoders.BASE64.decode(secret).length >= 32;
+        } catch (IllegalArgumentException exception) {
+            return false;
+        }
+    }
 
     /**
      * token默认过期时间

--- a/framework/src/main/java/cn/lili/common/security/token/SecretKeyUtil.java
+++ b/framework/src/main/java/cn/lili/common/security/token/SecretKeyUtil.java
@@ -1,8 +1,9 @@
 package cn.lili.common.security.token;
 
-import io.jsonwebtoken.io.Decoders;
+import cn.lili.common.properties.JWTTokenProperties;
+import cn.lili.common.utils.SpringContextUtil;
 import io.jsonwebtoken.security.Keys;
-import org.apache.commons.codec.binary.Base64;
+import io.jsonwebtoken.io.Decoders;
 
 import javax.crypto.SecretKey;
 
@@ -15,14 +16,11 @@ import javax.crypto.SecretKey;
  */
 public class SecretKeyUtil {
     public static SecretKey generalKey() {
-        //自定义
-        byte[] encodedKey = Base64.decodeBase64("cuAihCz53DZRjZwbsGcZJ2Ai6At+T142uphtJMsk7iQ=");
-        SecretKey key = Keys.hmacShaKeyFor(encodedKey);
-        return key;
+        JWTTokenProperties tokenProperties = SpringContextUtil.getBean(JWTTokenProperties.class);
+        return Keys.hmacShaKeyFor(Decoders.BASE64.decode(tokenProperties.getSecret()));
     }
 
     public static SecretKey generalKeyByDecoders() {
-        return Keys.hmacShaKeyFor(Decoders.BASE64.decode("cuAihCz53DZRjZwbsGcZJ2Ai6At+T142uphtJMsk7iQ="));
-
+        return generalKey();
     }
 }

--- a/im-api/src/main/resources/application.yml
+++ b/im-api/src/main/resources/application.yml
@@ -205,6 +205,8 @@ lili:
 
   # jwt 细节设定
   jwt-setting:
+    # Base64-encoded JWT signing key, injected per deployment.
+    secret: ${LILI_JWT_SECRET:}
     # token过期时间（分钟）
     tokenExpireTime: 60
 

--- a/manager-api/src/main/resources/application.yml
+++ b/manager-api/src/main/resources/application.yml
@@ -172,6 +172,8 @@ lili:
     currentOnlineUpdate: 600
   # jwt 细节设定
   jwt-setting:
+    # Base64-encoded JWT signing key, injected per deployment.
+    secret: ${LILI_JWT_SECRET:}
     # token过期时间（分钟）
     tokenExpireTime: 86400
 
@@ -226,4 +228,3 @@ rocketmq:
     send-message-timeout: 30000
   consumer:
     group: lili_consumer_group
-

--- a/manager-api/src/test/resources/application.yml
+++ b/manager-api/src/test/resources/application.yml
@@ -219,6 +219,8 @@ lili:
 
   # jwt 细节设定
   jwt-setting:
+    # Base64-encoded JWT signing key, injected per deployment.
+    secret: ${LILI_JWT_SECRET:}
     # token过期时间（分钟）
     tokenExpireTime: 30
 

--- a/seller-api/src/main/resources/application.yml
+++ b/seller-api/src/main/resources/application.yml
@@ -162,6 +162,8 @@ lili:
     currentOnlineUpdate: 600
   # jwt 细节设定
   jwt-setting:
+    # Base64-encoded JWT signing key, injected per deployment.
+    secret: ${LILI_JWT_SECRET:}
     # token过期时间（分钟）
     tokenExpireTime: 86400
 


### PR DESCRIPTION
## Summary

- Remove the hardcoded JWT signing key from `SecretKeyUtil`.
- Load one deployment-provided Base64 secret through `LILI_JWT_SECRET` for all API modules.
- Fail during application startup when the secret is missing, invalid, or shorter than 32 bytes of key material.
- Document secure JWT secret configuration in both README files.

Fixes #66

## Security impact

The previous constant key was present in the public source and was shared by all deployments. Anyone who obtained the source could create JWTs with attacker-controlled identity and authorization claims.

This does not mean that every Lilishop endpoint can be taken over with the key alone. The manager, store, and buyer authentication filters also require the complete token to exist in Redis. A forged token without that exact Redis entry is rejected on those paths.

However, the signing key still breaks JWT authenticity, and the repository also contains stateless consumers of the JWT context. For example, the current `common-api` security configuration permits requests and `FileDirectoryController` calls `UserContext.getCurrentUser()`, which verifies the signature but does not require the exact Redis token entry. In a local deployment using the official MySQL/Redis/Elasticsearch stack, a forged administrator context generated from the old key received HTTP 200 from that path, while the strict cache-gated path returned HTTP 403.

This change removes the public default and prevents a service from starting without an explicitly configured signing key.

## Configuration

```bash
export LILI_JWT_SECRET="$(openssl rand -base64 32)"
```

The same value must be supplied to every API service in a deployment. The value is Base64-encoded key material and is not committed to the repository.

## Validation

- `mvn clean install -DskipTests -T 1C` passes for all 8 modules.
- Startup without `LILI_JWT_SECRET` fails with `lili.jwt-setting.secret must be configured`.
- Startup with a short key fails with the 32-byte validation message.
- Startup with a generated 32-byte Base64 key succeeds and reports actuator health `UP`.
- The previous hardcoded key is absent from source and configuration files.
- Dynamic HTTP verification and the endpoint scope are documented in the accompanying research record.
